### PR TITLE
modified code to mount home directory

### DIFF
--- a/jazzy/Dockerfile
+++ b/jazzy/Dockerfile
@@ -60,7 +60,7 @@ RUN sudo apt update && sudo apt install locales \
 
 ARG ROSDIST=jazzy
 ARG GZDIST=harmonic
-ENV GZ_VERSION harmonic
+ENV GZ_VERSION=harmonic
 
 # Install Gazebo and ROS2 Desktop
 RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \

--- a/run.bash
+++ b/run.bash
@@ -52,7 +52,7 @@ ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --user --home 
 while getopts ":cstxhir" option; do
   case $option in
     c) # enable cuda library support and mount home directory
-      CUDA="--cuda "
+      CUDA="--cuda"
       ROCKER_ARGS="${ROCKER_ARGS} --volume $(echo ~):/home/docker";;
     i) # With internal graphics card (without nvidia)
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --home --git";;

--- a/run.bash
+++ b/run.bash
@@ -47,17 +47,18 @@ Help()
 
 JOY=/dev/input/js0
 CUDA=""
-ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --git --volume $(echo ~):/docker/HOST"
+ROCKER_ARGS="--devices /dev/dri $JOY --dev-helpers --nvidia --x11 --user --home --git"
 
 while getopts ":cstxhir" option; do
   case $option in
-    c) # enable cuda library support 
-      CUDA="--cuda";;
+    c) # enable cuda library support and mount home directory
+      CUDA="--cuda "
+      ROCKER_ARGS="${ROCKER_ARGS} --volume $(echo ~):/home/docker";;
     i) # With internal graphics card (without nvidia)
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --volume $(echo ~):/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --home --git";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 
@@ -83,4 +84,4 @@ CONTAINER_NAME="$(tr ':' '_' <<< "$IMG_NAME")_runtime"
 ROCKER_ARGS="${ROCKER_ARGS} --name $CONTAINER_NAME"
 echo "Using image <$IMG_NAME> to start container <$CONTAINER_NAME>"
 
-rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME 
+rocker ${CUDA} ${ROCKER_ARGS} $IMG_NAME

--- a/run.bash
+++ b/run.bash
@@ -58,7 +58,7 @@ while getopts ":cstxhir" option; do
       ROCKER_ARGS="--devices /dev/dri $JOY --x11 --user --home --git";;
     r) # With internal graphics card (without nvidia) and with RDP default user is docker
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --home --port 3389:3389 --volume $(echo ~):/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --home --port 3389:3389";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 


### PR DESCRIPTION
This pull request resolves an issue, enabling the Home directory to be mounted when running Docker on Linux.

- **Using Rocker flags instead of manual volume mounts**  
  Replaces  
  ```bash
  --volume $(echo ~):/docker/HOST

with 

```bash
  --home   # mounts $HOME → /home/docker  
  --user

