### PR TITLE
add fuse and priviledge for macos rdp

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -61,7 +61,7 @@ while getopts ":cstxhirp:" option; do
     r) # With internal graphics card (without nvidia) and with RDP. 
       # The default user in container is 'docker' due to RDP constraints (custom host port can be set via the -p option)
       # shellcheck disable=SC2116
-      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST";;
+      ROCKER_ARGS="--devices /dev/dri $JOY --x11 --git --port "$HOST_RDP_PORT":3389 --volume "$HOME":/home/docker/HOST --device /dev/fuse --privileged";;
     s) # Build cloudsim image
       ROCKER_ARGS="--nvidia --novnc --turbovnc --user --user-override-name=developer";;
     t) # Build test image for Continuous Integration 


### PR DESCRIPTION
This pull request makes a small but important change to the `run.bash` script, specifically for the option that configures the container to run with an internal graphics card and RDP. The change adds support for FUSE devices and grants privileged access to the container, which may be required for certain operations within the container.

- Added `--device /dev/fuse` and `--privileged` flags to the `ROCKER_ARGS` for the `r` option in `run.bash`, enabling FUSE support and privileged mode for containers started with internal graphics and RDP.